### PR TITLE
Add --fix-missing to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:20.04
 
 # Install all the necessary packages
-RUN apt-get update
+RUN apt-get update --fix-missing
 RUN apt-get install -y sqlite3
 RUN apt-get install -y make
 RUN apt-get install -y unzip


### PR DESCRIPTION
For me the installation of `sqlite3` only worked with the `--fix-missing` parameter being added to the `apt-get update` command.