### PR TITLE
(fix) INTTEGER typo in create-empty-table.sql

### DIFF
--- a/sql/create-empty-table.sql
+++ b/sql/create-empty-table.sql
@@ -1,4 +1,4 @@
 CREATE TABLE sample (
-    column01 INTTEGER,
+    column01 INTEGER,
     column02 TEXT
 );


### PR DESCRIPTION
Fix for a typo in sample file for interview.